### PR TITLE
support 'platform' as placeholder

### DIFF
--- a/README.org
+++ b/README.org
@@ -104,7 +104,7 @@ Example: arctee '/exports/rtm/{utcnow}.ical.zstd' --compression zstd --retries 3
 Arguments past '--' are the actuall command to run.
 
 positional arguments:
-  path                  Path with borg-style placeholders. Supported: {utcnow}, {hostname}.
+  path                  Path with borg-style placeholders. Supported: {utcnow}, {hostname}, {platform}.
                         
                         Example: '/exports/pocket/pocket_{utcnow}.json'
                         

--- a/arctee.py
+++ b/arctee.py
@@ -79,6 +79,7 @@ If you think any of these things can be simplified, I'd be happy to know and rem
   [[https://www.nongnu.org/atool][atool]] is a tool to create archives in any format. Only necessary if you want to use compression.
 """
 
+import sys
 import argparse
 from pathlib import Path
 import logging
@@ -110,11 +111,16 @@ def hostname() -> str:
     return socket.gethostname()
 
 
+def platform() -> str:
+    return sys.platform
+
+
 # don't think anything standard for that exists?
 # https://github.com/borgbackup/borg/blob/d02356e9c06f980b3d53459c6cc9c264d23d499e/src/borg/helpers/parseformat.py#L205
 PLACEHOLDERS = {
     'utcnow'  : utcnow,
     'hostname': hostname,
+    'platform': platform,
 }
 
 


### PR DESCRIPTION
added the ability to use `{platform}` in the filename, which just gets replaced to one of the values in the table [here](https://docs.python.org/3/library/sys.html#sys.platform)

didn't put the `sys` in the function since `sys` is definitely already imported at that point

example

```python
 ./arctee.py "{utcnow}-{hostname}-{platform}" -- cat $ZDOTDIR/.zsh_history
2021-03-28 15:12:22,750 Running 'cat /home/sean/.config/zsh/.zsh_history'
2021-03-28 15:12:22,764 Stderr:
2021-03-28 15:12:22,764 writing 8631222 bytes to 20210328T221222Z-bastion-linux
```

