### PR TITLE
add basic setuptools install, update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*$py.class

--- a/README.org
+++ b/README.org
@@ -74,14 +74,17 @@ Sadly, there are serious caveats:
 It feels that cron isn't a suitable tool for my needs due to pipe handling and the need for retries, however I haven't found a better alternative.
 If you think any of these things can be simplified, I'd be happy to know and remove them in favor of more standard solutions!
 
-* Dependencies
-- =pip3 install --user atomicwrites=
+* Installation
 
-  [[https://github.com/untitaker/python-atomicwrites][atomicwrites]] is a library for portable atomic file writing
-- =pip3 install --user backoff= (optional)
+This can be installed with pip by running: =pip3 install --user 'git+https://github.com/karlicoss/arctee'=
+
+You can also manually install this by installing =atomicwrites= (=pip3 install atomicwrites=) and downloading and running =arctee.py= directly
+
+** Optional Dependencies
+- =pip3 install --user backoff=
 
   [[https://github.com/litl/backoff][backoff]] is a library to simplify backoff and retrying. Only necessary if you want to use --retries--.
-- =apt install atool= (optional)
+- =apt install atool=
 
   [[https://www.nongnu.org/atool][atool]] is a tool to create archives in any format. Only necessary if you want to use compression.
 
@@ -90,12 +93,12 @@ If you think any of these things can be simplified, I'd be happy to know and rem
 * Usage
 
 #+begin_src sh :results output :exports output
-./arctee.py --help
+arctee --help
 #+end_src
 
 # TODO ugh. seems that github chokes over #+RESULT: here
 #+begin_example
-usage: arctee.py [-h] [-r RETRIES] [-c COMPRESSION] path
+usage: arctee [-h] [-r RETRIES] [-c COMPRESSION] path
 
 Wrapper for automating boilerplate for reliable and regular data exports.
 
@@ -105,9 +108,9 @@ Arguments past '--' are the actuall command to run.
 
 positional arguments:
   path                  Path with borg-style placeholders. Supported: {utcnow}, {hostname}, {platform}.
-                        
+
                         Example: '/exports/pocket/pocket_{utcnow}.json'
-                        
+
                         (see https://manpages.debian.org/testing/borgbackup/borg-placeholders.1.en.html)
 
 optional arguments:
@@ -116,7 +119,7 @@ optional arguments:
                         Total number of tries, 1 (default) means only try once. Uses exponential backoff.
   -c COMPRESSION, --compression COMPRESSION
                         Set compression format.
-                        
+
                         See 'man apack' for list of supported formats. In addition, 'zstd' is also supported.
 #+end_example
 

--- a/arctee.py
+++ b/arctee.py
@@ -67,14 +67,17 @@ Sadly, there are serious caveats:
 It feels that cron isn't a suitable tool for my needs due to pipe handling and the need for retries, however I haven't found a better alternative.
 If you think any of these things can be simplified, I'd be happy to know and remove them in favor of more standard solutions!
 
-* Dependencies
-- =pip3 install --user atomicwrites=
+* Installation
 
-  [[https://github.com/untitaker/python-atomicwrites][atomicwrites]] is a library for portable atomic file writing
-- =pip3 install --user backoff= (optional)
+This can be installed with pip by running: =pip3 install --user 'git+https://github.com/karlicoss/arctee'=
+
+You can also manually install this by installing =atomicwrites= (=pip3 install atomicwrites=) and downloading and running =arctee.py= directly
+
+** Optional Dependencies
+- =pip3 install --user backoff=
 
   [[https://github.com/litl/backoff][backoff]] is a library to simplify backoff and retrying. Only necessary if you want to use --retries--.
-- =apt install atool= (optional)
+- =apt install atool=
 
   [[https://www.nongnu.org/atool][atool]] is a tool to create archives in any format. Only necessary if you want to use compression.
 """

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+
+def main():
+    name = 'arctee'
+    setup(
+        name=name,
+        zip_safe=False,
+        py_modules=[name],
+        install_requires=['atomicwrites'],
+        entry_points={'console_scripts': ['arctee = arctee:main']},
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
add a basic setup.py so that this is installable with pip, updated the documentation to reflect installation instructions

first time using the `#begin_src` stuff to generate the docs (and org-mode in general I suppose) - think I was able to mostly figure it out.

of course org mode has solved this issue, then theres me [solving the same thing](https://github.com/seanbreckenridge/pmark) with regex for markdown